### PR TITLE
Escape .'s in file names when replacing text

### DIFF
--- a/expected/rev-manifest.json
+++ b/expected/rev-manifest.json
@@ -1,5 +1,6 @@
 {
   "images/dummy.jpg": "images/dummy-7051c65f.jpg",
+  "scripts/application.js": "scripts/application-5c2dec97.js",
   "scripts/script.js": "scripts/script-57cb6b72.js",
   "styles/styles.css": "styles/styles-5f3db2f0.css"
 }

--- a/fixtures/scripts/application.js
+++ b/fixtures/scripts/application.js
@@ -1,0 +1,10 @@
+var someFunction = function() {
+  $.ajax({
+    url: 'someurl',
+    type:"POST",
+    data:data,
+    contentType:"application/json; charset=utf-8",
+    dataType:"json",
+    success: function(){}
+  })
+}

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = function override() {
             if ((allowedPathRegExp.test(_f.file.revOrigPath) ) && _f.file.contents) {
                 var contents = _f.file.contents.toString();
                 f.forEach(function (__f) {
-                    contents = contents.replace(new RegExp(__f.origPath, 'g'), __f.hashedPath);
+                    contents = contents.replace(
+                        new RegExp(__f.origPath.replace('.', "\\."), 'g'),
+                        __f.hashedPath);
                 });
 
                 try {

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ var expect = require('chai').expect;
 describe('gulp-rev-css-url', function () {
     beforeEach(function (done) {
         fse.remove('./results', done);
+        done();
     })
 
     it('Should override urls in css and js', function (done) {
@@ -33,6 +34,20 @@ describe('gulp-rev-css-url', function () {
                 // check manifest
                 expect(manifest).to.deep.equal(expectedManifest);
 
+                done();
+            });
+    });
+
+    it('Should not replace application/json with application.js', function(done) {
+        gulp.src('./fixtures/scripts/application.js')
+            .pipe(rev())
+            .pipe(override())
+            .pipe(gulp.dest('./results/'))
+            .on('end', function () {
+                var js = fs.readFileSync(
+                    './results/application-5c2dec97.js',
+                    'utf-8');
+                expect(js).to.contain('application/json');
                 done();
             });
     });


### PR DESCRIPTION
Want it to match on actual dots, not any character. Ran into an issue with
"application.js" matching on "application/json" and breaking AJAX requests for
JSON resources.
