### PR TITLE
resolve base path

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,11 @@ module.exports = function override() {
 
         if (file.path && file.revOrigPath) {
             firstFile = firstFile || file;
-            var _relPath = relPath(firstFile.revOrigBase, file.revOrigPath);
+            var _relPath = relPath(path.resolve(firstFile.revOrigBase), file.revOrigPath);
+
             f.push({
                 origPath: _relPath,
-                hashedPath: relPath(firstFile.base, file.path),
+                hashedPath: relPath(path.resolve(firstFile.base), file.path),
                 file: file
             });
         }


### PR DESCRIPTION
resolving the base path makes it possible to pass a relative base in gulp.src,
eg: 

``` javascript
gulp.src(['./fixtures/images/*','./fixtures/scripts/*','./fixtures/styles/*'], {base: './fixtures'});
```
