### PR TITLE
Fix cross platform slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function override() {
             if ((allowedPathRegExp.test(_f.file.revOrigPath) ) && _f.file.contents) {
                 var contents = _f.file.contents.toString();
                 f.forEach(function (__f) {
-                    var origPath = __f.origPath.replace(new RegExp('\\' + path.sep, 'g'), '/').replace(/\./g, "\\.");
+                    var origPath = __f.origPath.replace(new RegExp('\\' + path.sep, 'g'), '/').replace(/\./g, '\\.');
                     var hashedPath = __f.hashedPath.replace(new RegExp('\\' + path.sep, 'g'), '/');
                     contents = contents.replace(
                         new RegExp(origPath, 'g'),


### PR DESCRIPTION
Filenames in rev-manifest.json end up with backslashes on Windows. Replace the backslashes with forward slashes as required.

Also fixes bug where if the file names have multiple "." in them only the first "." would be replaced.
