### PR TITLE
Preserve the pipeline's order

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,17 +36,18 @@ module.exports = function override() {
                 hashedPath: relPath(path.resolve(firstFile.base), file.path),
                 file: file
             });
-
-            // sort by filename length to not replace the common part(s) of several filenames
-            f.sort(function (a, b) {
-                if(a.origPath.length > b.origPath.length) return -1;
-                if(a.origPath.length < b.origPath.length) return 1;
-                return 0;
-            });
         }
         cb();
     }, function (cb) {
         var self = this;
+
+        // sort by filename length to not replace the common part(s) of several filenames
+        f.sort(function (a, b) {
+            if(a.origPath.length > b.origPath.length) return -1;
+            if(a.origPath.length < b.origPath.length) return 1;
+            return 0;
+        });
+
         f.forEach(function (_f) {
             var file = _f.file;
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function override() {
         var self = this;
 
         // sort by filename length to not replace the common part(s) of several filenames
-        f.sort(function (a, b) {
+        var longestFirst = f.slice().sort(function (a, b) {
             if(a.origPath.length > b.origPath.length) return -1;
             if(a.origPath.length < b.origPath.length) return 1;
             return 0;
@@ -53,7 +53,7 @@ module.exports = function override() {
 
             if ((allowedPathRegExp.test(file.revOrigPath) ) && file.contents) {
                 var contents = file.contents.toString();
-                f.forEach(function (__f) {
+                longestFirst.forEach(function (__f) {
                     var origPath = __f.origPath.replace(new RegExp('\\' + path.sep, 'g'), '/').replace(/\./g, '\\.');
                     var hashedPath = __f.hashedPath.replace(new RegExp('\\' + path.sep, 'g'), '/');
                     contents = contents.replace(

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var gulp = require('gulp');
 var fse = require('fs-extra');
 var override = require('./index');
 var expect = require('chai').expect;
+var through = require('through2');
 
 describe('gulp-rev-css-url', function () {
     beforeEach(function (done) {
@@ -55,6 +56,23 @@ describe('gulp-rev-css-url', function () {
                 expect(js).to.contain('application/json');
                 done();
             });
+    });
+
+    it('Should not reorder the pipeline', function (done) {
+        var outputOrder = [];
+        gulp.src(['./fixtures/scripts/script.js', './fixtures/scripts/application.js'])
+            .pipe(rev())
+            .pipe(override())
+            .pipe(through.obj(
+                function (file, enc, cb) {
+                    outputOrder.push(file.revOrigPath.replace(file.revOrigBase, ''));
+                    cb(null, file);
+                },
+                function (cb) {
+                    expect(outputOrder).to.deep.equal(['script.js', 'application.js']);
+                    done();
+                }
+            ));
     });
 
 });


### PR DESCRIPTION
The pipeline gets re-sorted by length of path, and for paths of the same length, the results are non-deterministic. This non-deterministic nature means that when I check `rev-manifest.json` in to a VCS, it'll sometimes have random changes in order, unrelated to my current source file changes.

This behavior was introduced in c2a9e54, as part of a fix for issues with similarly-named files. (It is non-deterministic because the callback given to `sort()` returns `0` for same-length paths without bothering to sort them in any other way. This isn't a problem for its internal goal.)

This PR isolates the length-sorting in a shallow clone of the main file list. It also adds a simple test of this issue.

(As a separate commit, this PR also changes the location of the `sort()` so that it only runs once rather than re-sorting after each path is received; this should be faster, but if you don't want this change, I can remove it from the PR.)