### PR TITLE
Adding license info to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gulp-rev-css-url",
   "version": "0.1.0",
   "description": "The lightweight plugin to override urls in css files to hashed after gulp-rev",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/galkinrost/gulp-rev-css-url"


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.